### PR TITLE
Add admin settings access and warehouse configuration tab

### DIFF
--- a/client/src/TopBar.jsx
+++ b/client/src/TopBar.jsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { useNavigate } from "react-router-dom";
 import logoUrl from "./assets/logo.png";
+import RoleGate from "./components/RoleGate.jsx";
 
 export default function TopBar() {
   const navigate = useNavigate();
@@ -29,18 +30,29 @@ export default function TopBar() {
           Sinyal Stok Sistemi
         </div>
 
-        {/* Profil (logout yok) */}
-        <button
-          className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
-          onClick={()=>navigate("/profil")}
-          title="Profil"
-        >
-          <img
-            src={sessionStorage.getItem("avatar") || "https://i.pravatar.cc/40"}
-            alt="avatar" width={24} height={24} style={{borderRadius:"50%"}}
-          />
-          <span>Profil</span>
-        </button>
+        {/* Yönetici ayarları + Profil */}
+        <div className="d-flex align-items-center gap-2">
+          <RoleGate allow={["yönetici"]}>
+            <button
+              className="btn btn-outline-secondary btn-sm"
+              onClick={()=>navigate("/ayarlar")}
+              title="Ayarlar"
+            >
+              Ayarlar
+            </button>
+          </RoleGate>
+          <button
+            className="btn btn-outline-secondary btn-sm d-flex align-items-center gap-2"
+            onClick={()=>navigate("/profil")}
+            title="Profil"
+          >
+            <img
+              src={sessionStorage.getItem("avatar") || "https://i.pravatar.cc/40"}
+              alt="avatar" width={24} height={24} style={{borderRadius:"50%"}}
+            />
+            <span>Profil</span>
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,33 +1,80 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+
+const WH_LS_KEY = "wh_list";
 
 export default function Settings(){
-  const [tab, setTab] = useState("users");
+  const [tab, setTab] = useState("general");
   return (
     <div className="bg-white rounded-2xl shadow p-3 p-md-4">
       <h5>Ayarlar</h5>
       <div className="btn-group mt-2">
-        <button className={"btn btn-sm "+(tab==="users"?"btn-dark":"btn-outline-secondary")} onClick={()=>setTab("users")}>Kullanıcı Yönetimi</button>
-        <button className={"btn btn-sm "+(tab==="tags"?"btn-dark":"btn-outline-secondary")} onClick={()=>setTab("tags")}>Etiketler</button>
+        <button className={"btn btn-sm "+(tab==="general"?"btn-dark":"btn-outline-secondary")} onClick={()=>setTab("general")}>Genel</button>
+        <button className={"btn btn-sm "+(tab==="warehouses"?"btn-dark":"btn-outline-secondary")} onClick={()=>setTab("warehouses")}>Depo Ayarları</button>
+        <button className={"btn btn-sm "+(tab==="users"?"btn-dark":"btn-outline-secondary")} onClick={()=>setTab("users")}>Kullanıcılar</button>
       </div>
 
-      {tab==="users" ? <UsersTab/> : <TagsTab/>}
+      {tab==="general" && <GeneralTab/>}
+      {tab==="warehouses" && <WarehouseTab/>}
+      {tab==="users" && <UsersTab/>}
+    </div>
+  );
+}
+
+function GeneralTab(){
+  return (
+    <div className="mt-3">
+      <div className="alert alert-info">Genel ayarlar yakında burada olacak.</div>
+    </div>
+  );
+}
+
+function WarehouseTab(){
+  const [rows, setRows] = useState([]);
+
+  useEffect(()=>{
+    try {
+      const raw = localStorage.getItem(WH_LS_KEY);
+      const arr = raw ? JSON.parse(raw) : [];
+      if (Array.isArray(arr)) setRows(arr);
+    } catch {}
+  },[]);
+
+  const toggle = (kod) => {
+    const upd = rows.map(r => r.kod===kod ? { ...r, etkilesin: !r.etkilesin } : r);
+    setRows(upd);
+    try { localStorage.setItem(WH_LS_KEY, JSON.stringify(upd)); } catch {}
+  };
+
+  if (rows.length===0) {
+    return <div className="mt-3 text-muted">Depo bulunamadı.</div>;
+  }
+
+  return (
+    <div className="table-responsive mt-3">
+      <table className="table align-middle">
+        <thead className="table-light">
+          <tr><th>Kod</th><th>Ad</th><th>Genel stoğu etkilesin mi?</th></tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.kod}>
+              <td className="fw-semibold">{r.kod}</td>
+              <td>{r.ad}</td>
+              <td>
+                <input type="checkbox" className="form-check-input" checked={!!r.etkilesin} onChange={()=>toggle(r.kod)} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   );
 }
 
 function UsersTab(){
-  // TODO: backend ile kullanıcı listesi ve rol atama
   return (
     <div className="mt-3">
-      <div className="alert alert-info">Kullanıcı listesi / rol atama ekranı (yönetici-kullanıcı-depocu) burada olacak.</div>
-    </div>
-  );
-}
-function TagsTab(){
-  // TODO: etiket yönetimi
-  return (
-    <div className="mt-3">
-      <div className="alert alert-info">Ürün etiketleri ekleme/silme/düzenleme burada olacak.</div>
+      <div className="alert alert-info">Kullanıcı yönetimi yakında...</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Show an Ayarlar button for administrators in the top bar
- Implement Settings page with General, Warehouse, and Users tabs
- Allow toggling whether warehouses affect general stock

## Testing
- `npm test` (client) *(fails: Missing script "test")*
- `npm test` (server) *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f07d688832c9b8f93b624c3a925